### PR TITLE
Add support for handling witness data and use hashlib for SHA-256 has…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "rsz",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/secp256k1/CHANGELOG.md
+++ b/secp256k1/CHANGELOG.md
@@ -1,0 +1,86 @@
+## Version: 0.1.16022025
+- Bugfix in load_bsgs_2nd. Reduced the overall size requirement of bsgs_2nd
+- Added bsgs_2nd_check_mcpu for checking all pubkeys together using multicpu
+- Generalized verify_message for other r/-r, s/-s cases
+- Shifted UpubData class to benchmark script
+
+
+## Version: 0.1.29012025
+- Changed hash function inside XOR Filter to xxhash
+- Revert back to -O2 compilation flag for varsatile usability .Fixed #63
+- Bugfix in bsgs_xor_create_mcpu for Element G
+- Minor speedup in create_valid_mnemonics
+
+
+## Version: 0.1.12012025
+- Integer with >N is handled in fl as Mod_N
+- Fixed #61
+- Added dump_bsgs_2nd / load_bsgs_2nd to dump / load the bsgs_2nd_check_prepare data to binary file.
+- In bsgs_2nd_check removed extra argument bP_elem
+- Added check_collision_mcpu as an extension of check_collision to use mcpu
+- Added rmd160 for RIPEmd160 and hash160 as RIPEmd160(SHA256)
+- Added create_burn_address for p2pkh compressed btc address to have some fun
+- Added point_division as a wrapper of inverse using point_multiplication
+- Added Operator Overloading class UpubData for (+/-*) simplification. Beware of runtime overhead
+- Added XOR Filter functions xor_para, fill_in_xor, dump_xor_file, read_xor_file, check_in_xor
+- Added bsgs_xor_create_mcpu for creating XOR filters using bsgs algo with multi cpu
+- Added check_in_xor_mcpu for multicpu search
+
+
+## Version: 0.1.27032024
+- Bugfix bloom_check_add_mcpu
+- Added one_to_6pubkey and one_to_6privatekey using symmetry and endomorphism property
+- Check if the Pubkey is on the curve using pubkey_isvalid
+- Added chunks for easy slicing of returned pubkey bytes
+- Added verify_message for bitcoin signature verification and rsz, pubkey extraction
+- Added sha512, hmac_sha512, bip39seed_to_bip32masternode and mnemonics_to_bip32masternode
+- Added parse_derivation_path for single and range of childkeys using (0-5)
+- Mnemonics generation with create_valid_mnemonics for English
+- mnem_to_privatekey, mnem_to_address wrapper for simplication of intermediate steps (single or range)
+- Privatekey for any derivation BIP44,49,84 BTC and maybe altcoin by specifying SLIP0044
+- root_key and fingerprint added. Not updated till xprv, xpub of Extended pvk,pub
+- pubkey_to_coinaddress added for #41 issue
+- bech32_address_decode modified for p2wsh. pubkey_to_p2wsh_address added.
+
+
+## Version: 0.1.18062023
+- Bugfix bloom_check_add_mcpu
+- Shifted functionalities from BSGS.dll to this library using create_bsgs_bloom_mcpu
+- Added addional check functions bsgs_2nd_check_prepare and bsgs_2nd_check to use in bsgs algo
+- Fill_in_bloom now also return the false probability and number of elements
+- dump_bloom_file and read_bloom_file takes also these 2 extra arguments _fp and _elem
+- Added function scalar_multiplications for multiple privatekey to Pubkey together from list of keys
+- transfer function point_multiplication to c++ for faster calculation
+- Incorporated PR39
+
+
+## Version: 0.1.18052022
+- Added checksum for sha256
+- Unsupported type ERROR in fl now print detected Type
+- Pubkey conversion functions added pub2upub, to_cpub, point_to_cpub
+- function bloom_check_add_mcpu added for later use
+- bloom_para, Fill_in_bloom, check_in_bloom helpful wrappers for bloom creation and test
+- prepare_bin_file, prepare_bin_file_work ideally to be used with rmd or eth to create .bin file
+- Once created the bloom can be saved and reloaded by dump_bloom_file, read_bloom_file
+- Option from .bin sorted file __20 byte each item__ to directly load into RAM using Load_data_to_memory
+- check for existence using check_collision function alongside Load_data_to_memory
+
+
+## Version: 0.1.29122021
+- Added version
+- privatekey_loop_h160_sse for using SSE advantage and privatekey_loop_h160 for old cpu
+- pbkdf2_hmac_sha512_list for working on a list of mnemonics at once
+- b58_encode and b58_decode added for base58 functions.
+- address_to_h160 and bech32_address_decode for converting back from address to hash160
+- Allowed return in bytes form of ETH functions. privatekey_to_ETH_address_bytes, privatekey_group_to_ETH_address_bytes, pubkey_to_ETH_address_bytes
+- point_multiplication added __rmul__ accidental usage
+- WIF format usage added. btc_wif_to_pvk_hex, btc_wif_to_pvk_int, btc_pvk_to_wif
+- Pointer Memory leakage Fix of issue #8
+- Fixed issue #5 of Zero Point Handling in different functions include vectors and sequentials
+- Added bloom functions based on xxhash. bloom_check_add, bloom_batch_add, test_bit_set_bit
+- Added sequential increment of NonG point using point_sequential_increment_P2 with initilization in init_P2_Group
+
+
+## Version: ----
+- Initial release of secp256k1 functions
+- Python Library for Secp256k1 Bitcoin curve to do fast ECC calculation (3.49 Million/s per cpu)

--- a/secp256k1/LICENSE
+++ b/secp256k1/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 iceland
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/secp256k1/README.md
+++ b/secp256k1/README.md
@@ -1,0 +1,337 @@
+# secp256k1
+Python Library for Secp256k1 Bitcoin curve to do fast ECC calculation (3.49 Million/s per cpu)
+
+# Info
+```
+Some functions have been added for easier and quicker use in a script.
+A Point is just a bytes form of correct length Full Pubkey. So 65 bytes exactly.
+
+point_loop_addition is just like starting from a point P and incrementing +G continuously m times. So we get P+G, P+2G, P+3G...... All these are returned concatenated in 65bytes*m.
+Same is the case with point_vector_addition but here two Point vectors are added together. Lets say 10points of 650bytes added with 10points of 650bytes to get added 650bytes.
+point_sequential_increment is similar to loop_increment except some vector trick is used to make it faster.
+Proper Zero Point handling added in functions.
+
+Many Altcoin Address support has been added. Although not checked all of them. 
+```
+
+# Example Usage
+```
+import secp256k1 as ice
+print('[C]',ice.privatekey_to_address(0, True, 42866423864328564389740932742094))
+: [C] 1EAKqa4DbqnxJ9uLUFrXTMSPd2k3fHzWgr
+print('[U]',ice.privatekey_to_address(0, False, 42866423864328564389740932742094))
+: [U] 1SXCEWFyUp6q4x92iR6JANNDAu87MNmSz
+print('[P2SH]',ice.privatekey_to_address(1, True, 42866423864328564389740932742094))
+: [P2SH] 3BDxuSY3g7SM2Zg3k6pkYxCgvk2JbcCx3M
+print('[Bech32]',ice.privatekey_to_address(2, True, 42866423864328564389740932742094))
+: [Bech32] bc1qjpw34q9px0eaqmnut2vfxndkthlh5qs9gt969u
+
+
+print(ice.scalar_multiplication(33604).hex())
+: 0488de60bd8c187071fc486979f2c9696c3602c562fbba6922993ff665eae81b4f8adf94f4e2a50b05fe35aee42c146f6415e5cf524b6b1b5a8d17de8b741a5a21
+
+P = ice.scalar_multiplication(33604)
+P.hex()
+: '0488de60bd8c187071fc486979f2c9696c3602c562fbba6922993ff665eae81b4f8adf94f4e2a50b05fe35aee42c146f6415e5cf524b6b1b5a8d17de8b741a5a21'
+
+ice.point_negation(P).hex()
+: '0488de60bd8c187071fc486979f2c9696c3602c562fbba6922993ff665eae81b4f75206b0b1d5af4fa01ca511bd3eb909bea1a30adb494e4a572e821738be5a20e'
+
+ice.point_doubling(P).hex()
+: '04484200af427941631f87f4ca153635156ceb0306e7033874e06a784088be5e3563868c14b34af7bc6206bcdbd63dee7a7825e595f8c45b07746e1b87da3091fc'
+
+ice.point_multiplication(P, 7).hex()
+: '048ea2016371a8e644f84252993527896b4c4d024a3e4e6c18246eb71b9c10363375be5a09dd9eaa819cdd50710309b5cc854aa910822be36cb28f88511132e4ce'
+
+Pn = ice.scalar_multiplications([43242, 543053, 329074523, 321785444032743])
+Pn[-65:].hex()
+: '04fe34b4c918a738c61f8e1fa594c737f452eba2f6a84a2f7912c0c4dc91957e4b0ca6ba19ef14bfbf08c21f2f69a93067eb99d9d08d069ee556dbfe17abfa931a'
+
+ice.pubkey_to_address(0, True, P)
+: '17eCpwzTCEDAbws2ucoZEy1iEcg1WrLKDp'
+
+ice.pubkey_to_address(0, False, P)
+: '1Ew5GpHRfXskxurzUHyaf9WwV9NdxHWdch'
+
+ice.pubkey_to_address(1, False, P)
+: ' P2SH: Only compressed key '
+
+ice.pubkey_to_address(1, True, P)
+: '382NUCrzpd9WkpyRzEtusMM5e6v5tNCHQg'
+
+ice.pubkey_to_address(2, True, P)
+: 'bc1qfrdqfz89qxllsg3wrj46f9pegung0n8vj53fsk'
+
+ice.pubkey_to_p2wsh_address(P)
+'bc1qs4l2yq57cznm87ty22mmllscq08sqgsvf06ap9usaug0h0cxsuas9jzg6y'
+
+ice.privatekey_to_h160(1, True, 0x437af32d9e723fb9cd0).hex()
+: '2ab7b63dd0de957b72df9eded24cd62e80d131f4'
+
+ice.privatekey_to_h160(1, False, 0x437af32d9e723fb9cd0).hex()
+: '3243394361fceaa57ae1a7ff32b48e30e8de3e5b'
+
+ice.pbkdf2_hmac_sha512_dll('good push broken people salad bar mad squirrel joy dismiss merge jeans token wear boring manual doll near sniff turtle sunset lend invest foil').hex()
+: '87aad6885223fa91dbca6f0a1f1816202832fd4264dc89365c745c0f1b0418d9065e33c2583cd8fb7f6f40c3dca65dec47dd7061105819833e630b6ebf085862'
+
+P3 = ice.point_loop_addition(100000, P, P2)
+P3[:65].hex()
+: '044d7161f5d186b0f453887cd74a0f684534eb334da2b0ddcb9b9e9c6d3060d4ec1ae05b6da9d17c0aa6c2ffe6d5bd43a13cc52e0ec2463ca92d271b878b8ed464'
+
+P3[-65:].hex()
+: '047ae2dadd8871465f988a40e57d9ff7f37eb67f4d244df11b010995a92dcdebaa040d43b7895e538b3b83789e3ab98faf6b9b4201d5a2ed7d4b0f11b1d59b853d'
+
+P4 = ice.point_sequential_increment(500000, P)
+P4[:65].hex()
+: '046ebfe8cd423c6c16fa29ce8aae12fa15b4ab78314773aa6453aa98b2bdcc10f66a43166c2f45267331dcf4a113aa584cd040fb0f8fe07326c28a8cb6b0f84149'
+
+ice.btc_pvk_to_wif(0x4732861b1f)
+: 'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9R7rErzLE79yTdy'
+ice.btc_pvk_to_wif(305790327583)
+: 'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9R7rErzLE79yTdy'
+ice.btc_pvk_to_wif('4732861b1f')
+: 'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9R7rErzLE79yTdy'
+ice.btc_pvk_to_wif(b'G2\x86\x1b\x1f')
+: 'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9R7rErzLE79yTdy'
+
+ice.btc_pvk_to_wif(0x4732861b1f, False)
+: '5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB4eoVyBj2oWsCR'
+
+ice.btc_wif_to_pvk_hex('KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9R7rErzLE79yTdy')
+: '0000000000000000000000000000000000000000000000000000004732861b1f'
+
+ice.address_to_h160('151F838jqc92vshQNBXXf95hSW5hHbXHDq')
+: '2bec4a80756fae715eec388727dacbca9ec34b54'
+
+ice.bech32_address_decode('bc1qdj7v4lgweum6g8r8fjh5gedrwtg0pmf32uxnsvtf27adav96gftsudprkk')
+: '6cbccafd0ecf37a41c674caf4465a372d0f0ed31570d38316957badeb0ba4257'
+ice.bech32_address_decode('bc1q90ky4qr4d7h8zhhv8zrj0kkte20vxj65uft745')
+: '2bec4a80756fae715eec388727dacbca9ec34b54'
+ice.bech32_address_decode('ltc1q90ky4qr4d7h8zhhv8zrj0kkte20vxj65c436dy', ice.COIN_LTC)
+: '2bec4a80756fae715eec388727dacbca9ec34b54'
+
+ice.pubkey_to_ETH_address(P)
+: '0xfa7e4d39a1fde2d03d01e298c31ee602bcdf4c85'
+
+ice.privatekey_to_ETH_address(43789543)
+: '0xf91262290187f5547839ae0c84b55892f39c5a9b'
+
+ice.privatekey_to_ETH_address_bytes(43789543).hex()
+: 'f91262290187f5547839ae0c84b55892f39c5a9b'
+
+ice.privatekey_group_to_ETH_address(43232, 4)
+: 'a760b12246759d603cca3686b95b1309772e9c30481fe3d921db92f0a0ad0012a852f0eaf05784feec0c24da5eeed9e7a6eb4477ee030289bf68311863b57e0e653620747c2339f48ba8cd60ea33ea88'
+
+ice.pub_endo1(P).hex()
+: '0441d68a94e621d33139103b6e4b9d8ac94103ba746952e4b322b7e7ba8c1d75d18adf94f4e2a50b05fe35aee42c146f6415e5cf524b6b1b5a8d17de8b741a5a21'
+
+ice.pub_endo2(P).hex()
+: '04354b14ad8dc5bc5ccaa75b17c1990bca88f980289af2b22a440821de88fa6b0f8adf94f4e2a50b05fe35aee42c146f6415e5cf524b6b1b5a8d17de8b741a5a21'
+
+ice.get_sha256('S6c56bnXQiBjk9mqSYE7ykVQ7NzrRy').hex()
+: '4c7a9640c72dc2099f23715d0c8a0d8a35f8906e3cab61dd3f78b67bf887c9ab'
+
+ice.get_sha256(P).hex()
+: '739c4ba018e1877d5c82fa60b7e2304776e7bf39af5dc9b4c05152ea78b822f9'
+
+ice.rmd160(P).hex()
+: '90c246d4c39680f26ff43c6bd742d0c0b542a600'
+
+ice.hash160(P).hex()
+: '98d3a9ed3eb034e9531f7a6d281d55422f1a1351'
+
+ice.privatekey_to_coinaddress(ice.COIN_LTC, 0, True, 0x1b1f)
+: 'LPb9na7qWdM7iHwKiiQmkQrhBtr11n8ywb'
+
+ice.privatekey_to_coinaddress(ice.COIN_DOGE, 0, True, 0x1b1f)
+: 'D9WJ4ckejP1LzVRmHAR329xXrpD2HhkX4Q'
+
+ice.privatekey_to_coinaddress(ice.COIN_DOGE, 0, False, 0x1b1f)
+: 'D7Q1YeimeNmgmn4HnRGJnFrpMkQWJK3bHn'
+
+ice.privatekey_to_coinaddress(ice.COIN_DASH, 0, True, 0x1b1f)
+: 'Xf43McTuPgKecRqkQTjhKvUip24Qza1qRF'
+
+ice.privatekey_to_coinaddress(ice.COIN_RVN, 0, True, 0x1b1f)
+: 'RDePbshJ2nudXVcN1kQbZv88jwwKWs42X6'
+
+ice.pubkey_to_coinaddress(16, 0, True, P)
+: 'DBnJNCw6Ve7T8x3deCo7njBK7kQJrfyMS4'
+
+ice.checksum('What is the use of it?').hex()
+: '6bbe6051'
+
+ice.create_burn_address('ADayWiLLcomeWheniceLandisGoingToSoLvebitCoinPuzzLe', 'X')
+: ['1ADayWiLLcomeWheniceLandisXXVF7Q3', '1GoingToSoLvebitCoinPuzzLeXXxuijG']
+
+for Q in ice.one_to_6pubkey(P): print(Q.hex())
+: 0488de60bd8c187071fc486979f2c9696c3602c562fbba6922993ff665eae81b4f8adf94f4e2a50b05fe35aee42c146f6415e5cf524b6b1b5a8d17de8b741a5a21
+: 0441d68a94e621d33139103b6e4b9d8ac94103ba746952e4b322b7e7ba8c1d75d18adf94f4e2a50b05fe35aee42c146f6415e5cf524b6b1b5a8d17de8b741a5a21
+: 04354b14ad8dc5bc5ccaa75b17c1990bca88f980289af2b22a440821de88fa6b0f8adf94f4e2a50b05fe35aee42c146f6415e5cf524b6b1b5a8d17de8b741a5a21
+: 0488de60bd8c187071fc486979f2c9696c3602c562fbba6922993ff665eae81b4f75206b0b1d5af4fa01ca511bd3eb909bea1a30adb494e4a572e821738be5a20e
+: 0441d68a94e621d33139103b6e4b9d8ac94103ba746952e4b322b7e7ba8c1d75d175206b0b1d5af4fa01ca511bd3eb909bea1a30adb494e4a572e821738be5a20e
+: 04354b14ad8dc5bc5ccaa75b17c1990bca88f980289af2b22a440821de88fa6b0f75206b0b1d5af4fa01ca511bd3eb909bea1a30adb494e4a572e821738be5a20e
+
+for kk in ice.one_to_6privatekey(48732985723059723057387687698969865642): print(hex(kk))
+: 0x24a9a1b3b4b27e77c678c06c13072daa
+: 0xc0b7df046e39daffe3fadab9447d0072de63cc3c8d135419aeeffd2b57c4aad3
+: 0x3f4820fb91c625001c052546bb82ff8bb7a16ef66d82cdaa4a69a0f5656a68c4
+: 0xfffffffffffffffffffffffffffffffe96053b32fa9621c3f9599e20bd2f1397
+: 0x3f4820fb91c625001c052546bb82ff8bdc4b10aa22354c2210e261617871966e
+: 0xc0b7df046e39daffe3fadab9447d0073030d6df041c5d2917568bd976acbd87d
+
+ice.pubkey_isvalid(P)
+: True
+
+ice.create_valid_mnemonics(256)
+: 'crater life cigar local parade soft sea yard argue lion body panic buddy olympic dose better topic trash six noodle order sugar similar wheat'
+
+m = ice.create_valid_mnemonics()
+ice.mnem_to_privatekey(m).hex()
+'a573867bcd4e83737eb30377591dcf3e052aa97f7c8d5892f7b947b4b30072b4'
+
+m = 'oval vapor neck three sing plunge east matter shaft cement dutch pepper hen know short'
+ice.btc_pvk_to_wif( ice.mnem_to_privatekey(m, "m/44'/0'/0'/0/0") )
+: 'KxuBKvRM4UGzuKYqk6aDCDdNrRCaQPm49fVmYgM1Em6x5GePE1om'
+ice.btc_pvk_to_wif( ice.mnem_to_privatekey(m, "m/49'/0'/0'/0/0") )
+: 'KyEYyzwLY2JSFAUzfuUzNmKFJApcYKJCRZANvyQa4Cw1mdSRSEoK'
+ice.btc_pvk_to_wif( ice.mnem_to_privatekey(m, "m/84'/0'/0'/0/0") )
+: 'L4AZnxZTMgVQWvabShYgCtx1A94n71P99onE3XxeBjTp9if7XJs1'
+
+for line in ice.mnem_to_privatekey(m, "m/44'/0'/0'/0/(10-12)"): print(line.hex())
+: c61b424e801a04f1490733dd470c84b38f5270cebe294c122cbe2ced02d450b0
+: a17a51c6b1cddf319ad90e20f8c1f618cd5fda4c0ac7d1f2e62cb761352af44f
+: de448783f0c32c4b02b29f97d06e3b2bd00d36a4e69db64bddff88993a1ef695
+
+ice.mnem_to_address(m, 2, True)
+'bc1qk4g3dt35uuzkrzzzd66ttafv9lfsamhpscam92'
+
+ice.mnem_to_address(m, 0, True, "m/44'/0'/0'/0/(0-3)")
+: ['1HXiSrdbhhPPoFNeKYpurap9PRnYHJiwj2', '1Kr6ZtaG86T7WGRtVxySsxfsYdZCjKNidE', '1HEufz6bsySRcfyaAjm3mHQaRTJqGzVo8n', '1Bxyj5EhgysjniyQzENqTLyxBtxoYbybae']
+
+ice.verify_message('1Fo65aKq8s8iquMt6weF1rku1moWVEd5Ua','IIONt3uYHbMh+vUnqDBGHP2gGu1Q2Fw0WnsKj05eT9P8KI2kGgPniiPirCd5IeLRnRdxeiehDxxsyn/VujUaX8o=', 
+'Anything one man can imagine, other men can make real')
+Rpoint: 04838db77b981db321faf527a830461cfda01aed50d85c345a7b0a8f4e5e4fd3fcb470f62d351e9e0f653cd78f74ecc381a92e5cb43f477f18284283d4150d6c8d
+r : 838db77b981db321faf527a830461cfda01aed50d85c345a7b0a8f4e5e4fd3fc
+s : 288da41a03e78a23e2ac277921e2d19d17717a27a10f1c6cca7fd5ba351a5fca
+z : 9233d997d01ccf4b46187b215819354f107e76d9c27968bc460e4463334ee7c3
+PubKey : 03633cbe3ec02b9401c5effa144c5b4d22f87940259634858fc7e59b1c09937852
+Address : 1Fo65aKq8s8iquMt6weF1rku1moWVEd5Ua
+
+signature is Valid and Address is Verified.
+
+-----BEGIN BITCOIN SIGNED MESSAGE-----
+Anything one man can imagine, other men can make real
+-----BEGIN BITCOIN SIGNATURE-----
+1Fo65aKq8s8iquMt6weF1rku1moWVEd5Ua
+IIONt3uYHbMh+vUnqDBGHP2gGu1Q2Fw0WnsKj05eT9P8KI2kGgPniiPirCd5IeLRnRdxeiehDxxsyn/VujUaX8o=
+-----END BITCOIN SIGNATURE-----
+
+
+xx = ['43253', 'hfoiefcope', 'cvt9', '4329r32hf39', '4e329jf4iehgf43']
+_bits, _hashes, _bf, _fp, _elem = ice.Fill_in_bloom(xx, 0.000001)
+print(ice.check_in_bloom('cvt9', _bits, _hashes, _bf))
+: True
+
+ice.dump_bloom_file("my_bloom_file.bin", _bits, _hashes, _bf, _fp, _elem)
+_bits, _hashes, _bf, _fp, _elem = ice.read_bloom_file("my_bloom_file.bin")
+print(ice.check_in_bloom('cvt9', _bits, _hashes, _bf))
+: True
+
+ice.bsgs_2nd_check_prepare(100000000)
+Q = ice.scalar_multiplication(0x10000000000000000000000005820545)
+found, pvk = ice.bsgs_2nd_check(Q, 0x10000000000000000000000000000000)
+print(found, pvk.hex())
+:  True 0000000000000000000000000000000010000000000000000000000005820545
+
+ice.dump_bsgs_2nd('file_2nd_dump.bin', True)
+: [+] [N2:5000000, N3:250000, N4:12500]  Vec4th Size    : 12500
+: [+] [bloom2nd (17 MB)] [bloom3rd (0 MB)] [bloom4th (0 MB)]
+
+ice.load_bsgs_2nd('file_2nd_dump.bin', True)
+: [+] [N2:5000000, N3:250000, N4:12500]  Vec4th Size    : 12500
+: [+] [bloom2nd (17 MB)] [bloom3rd (0 MB)] [bloom4th (0 MB)]
+
+founds, pvks = ice.bsgs_2nd_check_mcpu(bigbuf_upubs, kk)
+int.from_bytes(found, 'big') > 0:
+: False
+
+
+P = ice.pub2upub('02CEB6CBBCDBDF5EF7150682150F4CE2C6F4807B349827DCDBDD1F2EFA885A2630')
+print(P.hex())
+: '04ceb6cbbcdbdf5ef7150682150f4ce2c6f4807b349827dcdbdd1f2efa885a26302b195386bea3f5f002dc033b92cfc2c9e71b586302b09cfe535e1ff290b1b5ac'
+
+ice.point_to_cpub(P)
+: '02ceb6cbbcdbdf5ef7150682150f4ce2c6f4807b349827dcdbdd1f2efa885a2630'
+
+ice.to_cpub('04ceb6cbbcdbdf5ef7150682150f4ce2c6f4807b349827dcdbdd1f2efa885a26302b195386bea3f5f002dc033b92cfc2c9e71b586302b09cfe535e1ff290b1b5ac')
+: '02ceb6cbbcdbdf5ef7150682150f4ce2c6f4807b349827dcdbdd1f2efa885a2630'
+
+ice.prepare_bin_file("eth_addr_file.txt", "eth_sorted.bin", True, True)
+ice.Load_data_to_memory("eth_sorted.bin", False)
+ice.check_collision(this_key_eth_bytes)
+: True
+
+Pn = [line for line in ice.chunks(ice.point_sequential_increment(4000, P))]
+for i in range(2784900, 2789900, 1500):  
+  print(i, ice.check_in_xor(ice.scalar_multiplication(i), _bits, _hashes, _xf))
+: 2784900 False
+: 2786400 True
+: 2787900 True
+: 2789400 False
+
+Q = b''; for i in range(2784900, 2789900, 1500): Q += ice.scalar_multiplication(i)
+print(ice.check_in_xor_mcpu(Q, 4, 65, 4, _bits, _hashes, _xf).hex())
+: 00010100
+
+dd = ice.bsgs_xor_create_mcpu(4, 10000000)
+: [+] XOR [bits: 335477043] [hashes: 23] [size: 41934630 Bytes] [false prob: 1e-07]
+: [+] Thread  0: 0x0000000000000001 -> 0x00000000002625A0
+: [+] Thread  1: 0x00000000002625A1 -> 0x00000000004C4B40
+: [+] Thread  2: 0x00000000004C4B41 -> 0x00000000007270E0
+: [+] Thread  3: 0x00000000007270E1 -> 0x0000000000989680
+: Progress: 10000000 / 10000000 entries completed (100.00%)
+
+
+```
+# Benchmark
+```
+(base) C:\Anaconda3> python benchmark.py
+
+P2PKH_C                        : PASS
+P2PKH_U                        : PASS
+P2SH                           : PASS
+Bech32                         : PASS
+Scalar_Multiplication          : PASS
+Point Negation                 : PASS
+Point Doubling                 : PASS
+Point Multiplication           : PASS
+[8/8] All check Passed...
+Operator Check                 : PASS
+Point Sequential Increment     : 1 loops, best of 5: 834.80 ms per loop
+Point Addition                 : 100000 loops, best of 5: 2.09 us per loop
+```
+
+# Speed
+On my old Laptop with i7 4810 MQ CPU
+```
+timeit ice.privatekey_to_address(0, True, 67)
+6.35 µs ± 41.4 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
+
+timeit ice.scalar_multiplication(3240945)
+3.1 µs ± 38.7 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
+
+timeit ice.point_multiplication(P, 25465786)
+13 µs ± 98.4 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
+
+timeit ice.point_increment(P)
+2.32 µs ± 20.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
+
+timeit ice.point_addition(P,P2)
+2.66 µs ± 17.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
+```
+With 3500000 continuous keys in 1 group call, we get 3.5 Miilion Key/s Speed with 1 cpu:
+```
+timeit ice.point_sequential_increment(3500000, P)
+817 ms ± 15.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
+```

--- a/secp256k1/benchmark.py
+++ b/secp256k1/benchmark.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""
+
+@author: iceland
+"""
+import secp256k1 as ice
+import timeit
+
+#==============================================================================
+# For Operator Overloading Purpose. Like P + Q, Q * 20, P / 5 etc etc.
+class UpubData:
+    def __init__(self, data):
+        if len(data) != 65:
+            raise ValueError("Data must be 65 bytes")
+        self.data = data
+    
+    def __add__(self, other):
+        if not isinstance(other, UpubData):
+            return NotImplemented
+        return UpubData(ice.point_addition(self.data, other.data))
+    
+    def __sub__(self, other):
+        if not isinstance(other, UpubData):
+            return NotImplemented
+        return UpubData(ice.point_subtraction(self.data, other.data))
+
+    def __neg__(self):
+        return UpubData(ice.point_negation(self.data))
+    
+    def __mul__(self, other):
+        if isinstance(other, int):
+            return UpubData(ice.point_multiplication(self.data, other))
+        return NotImplemented
+
+    def __rmul__(self, other):
+        return self.__mul__(other)
+
+    def __truediv__(self, other):
+        if isinstance(other, int):
+            return UpubData(ice.point_division(self.data, other))
+        return NotImplemented
+    
+    def to_bytes(self): 
+        return self.data
+    
+    def __repr__(self):
+        return f"UpubData({self.data})"
+    
+    def __str__(self): 
+        return f"{self.data.hex()}"
+
+def upub(data): 
+    if isinstance(data, UpubData): 
+        return data 
+    return UpubData(data)
+#==============================================================================
+# Example. Q = (((P * 160 )-P) /77).to_bytes()
+
+def fix_time(val):
+    units = [("ms", 1e3), ("us", 1e6), ("ns", 1e9)]
+    for unit, factor in units:
+        if val >= 1 / factor:
+            return f"{val * factor:.2f} {unit}"
+
+def chk(mess, i, o):
+    if i == o: print(f'{mess:<30} : PASS')
+    else: print(f'{mess:<30} : FAIL')
+
+def self_check():
+    pvk = 42866423864328564389740932742094
+    chk('P2PKH_C', ice.privatekey_to_address(0, True, pvk), '1EAKqa4DbqnxJ9uLUFrXTMSPd2k3fHzWgr')
+    chk('P2PKH_U', ice.privatekey_to_address(0, False, pvk), '1SXCEWFyUp6q4x92iR6JANNDAu87MNmSz')
+    chk('P2SH', ice.privatekey_to_address(1, True, pvk), '3BDxuSY3g7SM2Zg3k6pkYxCgvk2JbcCx3M')
+    chk('Bech32', ice.privatekey_to_address(2, True, pvk), 'bc1qjpw34q9px0eaqmnut2vfxndkthlh5qs9gt969u')
+    
+    pvk = 33604
+    P = ice.scalar_multiplication(pvk)
+    chk('Scalar_Multiplication', P.hex(), '0488de60bd8c187071fc486979f2c9696c3602c562fbba6922993ff665eae81b4f8adf94f4e2a50b05fe35aee42c146f6415e5cf524b6b1b5a8d17de8b741a5a21')
+    chk('Point Negation', ice.point_negation(P).hex(), '0488de60bd8c187071fc486979f2c9696c3602c562fbba6922993ff665eae81b4f75206b0b1d5af4fa01ca511bd3eb909bea1a30adb494e4a572e821738be5a20e')
+    chk('Point Doubling', ice.point_doubling(P).hex(), '04484200af427941631f87f4ca153635156ceb0306e7033874e06a784088be5e3563868c14b34af7bc6206bcdbd63dee7a7825e595f8c45b07746e1b87da3091fc')
+    chk('Point Multiplication', ice.point_multiplication(P, 7).hex(), '048ea2016371a8e644f84252993527896b4c4d024a3e4e6c18246eb71b9c10363375be5a09dd9eaa819cdd50710309b5cc854aa910822be36cb28f88511132e4ce')
+    print('[8/8] All check Passed...')
+
+def op_check():
+    pvk = 0x437af32d9e723fb9cd0
+    Q = upub(ice.scalar_multiplication(pvk))
+    G = upub(ice.scalar_multiplication(1))
+    R = Q * 25 - G * 8
+    chk('Operator Check', R.to_bytes(), ice.scalar_multiplication(0x69701bf7479283925048))
+    
+def speed_check(mess, setup_code, test_code):
+    timer = timeit.Timer(stmt=test_code, setup=setup_code)
+    number, _ = timer.autorange()
+    execution_times = timer.repeat(repeat=5, number=number)
+    best_time = min(execution_times)
+    time_per_loop = fix_time(best_time / number)
+    print(f"{mess:<30} : {number} loops, best of 5: {time_per_loop} per loop")
+
+#==============================================================================
+setup_code = """import secp256k1 as ice; pvk = 0xf5ef7150682150f4ce2c6f4807b349827dcdbd
+P = ice.scalar_multiplication(pvk)"""
+
+test_code = """
+ice.point_sequential_increment(3500000, P)
+"""
+
+self_check()
+op_check()
+speed_check("Point Sequential Increment", setup_code, test_code)
+speed_check("Point Addition", setup_code, """ice.point_addition(P, P)""")

--- a/secp256k1/secp256k1.py
+++ b/secp256k1/secp256k1.py
@@ -1,0 +1,1197 @@
+# -*- coding: utf-8 -*-
+"""
+
+@author: iceland
+"""
+
+import platform
+import os
+import sys
+import ctypes
+import math
+import pickle
+import base64
+###############################################################################
+N = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
+Zero=b'\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+#==============================================================================
+if platform.system().lower().startswith('win'):
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    dllfile = dir_path + '/ice_secp256k1.dll'
+    if os.path.isfile(dllfile) == True:
+        pathdll = os.path.realpath(dllfile)
+        ice = ctypes.CDLL(pathdll)
+    else:
+        print('File {} not found'.format(dllfile))
+    
+elif platform.system().lower().startswith('lin'):
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    dllfile = dir_path + '/ice_secp256k1.so'
+    if os.path.isfile(dllfile) == True:
+        pathdll = os.path.realpath(dllfile)
+        ice = ctypes.CDLL(pathdll)
+    else:
+        print('File {} not found'.format(dllfile))
+    
+else:
+    print('[-] Unsupported Platform currently for ctypes dll method. Only [Windows and Linux] is working')
+    sys.exit()
+###############################################################################
+#==============================================================================
+# Coin type
+COIN_BTC  = 0
+COIN_BSV  = 1
+COIN_BTCD = 2
+COIN_ARG  = 3
+COIN_AXE  =	4
+COIN_BC   = 5
+COIN_BCH  = 6
+COIN_BSD  =	7
+COIN_BTDX = 8 
+COIN_BTG  =	9
+COIN_BTX  =	10
+COIN_CHA  =	11
+COIN_DASH = 12
+COIN_DCR  =	13
+COIN_DFC  =	14
+COIN_DGB  =	15
+COIN_DOGE = 16
+COIN_FAI  =	17
+COIN_FTC  =	18
+COIN_GRS  =	19
+COIN_JBS  =	20
+COIN_LTC  =	21
+COIN_MEC  =	22
+COIN_MONA = 23
+COIN_MZC  =	24
+COIN_PIVX = 25
+COIN_POLIS= 26
+COIN_RIC  = 27
+COIN_STRAT= 28
+COIN_SMART= 29
+COIN_VIA  = 30
+COIN_XMY  =	31
+COIN_ZEC  =	32
+COIN_ZCL  =	33
+COIN_ZERO = 34
+COIN_ZEN  =	35
+COIN_TENT = 36
+COIN_ZEIT = 37
+COIN_VTC  =	38
+COIN_UNO  =	39
+COIN_SKC  =	40
+COIN_RVN  =	41
+COIN_PPC  =	42
+COIN_OMC  =	43
+COIN_OK   =	44
+COIN_NMC  =	45
+COIN_NLG  =	46
+COIN_LBRY =	47
+COIN_DNR  =	48
+COIN_BWK  =	49
+#==============================================================================
+# Mnem Lang [Only English is Enabled. No other Language Actiavted yet]
+MNEM_EN  = 0            # English
+MNEM_JP  = 1            # Japanese
+MNEM_KR  = 2            # Korean
+MNEM_SP  = 3            # Spanish
+MNEM_CS  = 4            # Chinese_simplified
+MNEM_CT  = 5            # Chinese_traditional
+MNEM_FR  = 6            # French
+MNEM_IT  = 7            # Italian
+MNEM_CZ  = 8            # Czech
+MNEM_PT  = 9            # Portuguese
+
+#==============================================================================
+ice.scalar_multiplication.argtypes = [ctypes.c_char_p, ctypes.c_char_p]   # pvk,ret
+#==============================================================================
+ice.scalar_multiplications.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p]  # pvk,len,ret
+#==============================================================================
+ice.get_x_to_y.argtypes = [ctypes.c_char_p, ctypes.c_bool, ctypes.c_char_p]   # x,even,ret
+#==============================================================================
+ice.point_increment.argtypes = [ctypes.c_char_p, ctypes.c_char_p] # upub,ret
+#==============================================================================
+ice.point_negation.argtypes = [ctypes.c_char_p, ctypes.c_char_p]  # upub,ret
+#==============================================================================
+ice.point_doubling.argtypes = [ctypes.c_char_p, ctypes.c_char_p]  # upub,ret
+#==============================================================================
+ice.privatekey_to_coinaddress.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_bool, ctypes.c_char_p]  # intcoin,012,comp,pvk
+ice.privatekey_to_coinaddress.restype = ctypes.c_void_p
+#==============================================================================
+ice.pubkey_to_coinaddress.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_bool, ctypes.c_char_p]  # intcoin,012,comp,upub
+ice.pubkey_to_coinaddress.restype = ctypes.c_void_p
+#==============================================================================
+ice.privatekey_to_address.argtypes = [ctypes.c_int, ctypes.c_bool, ctypes.c_char_p]  # 012,comp,pvk
+ice.privatekey_to_address.restype = ctypes.c_void_p
+#==============================================================================
+ice.pubkey_to_p2wsh_address.argtypes = [ctypes.c_char_p]  # upub
+ice.pubkey_to_p2wsh_address.restype = ctypes.c_void_p
+#==============================================================================
+ice.hash_to_address.argtypes = [ctypes.c_int, ctypes.c_bool, ctypes.c_char_p]  # 012,comp,hash
+ice.hash_to_address.restype = ctypes.c_void_p
+#==============================================================================
+ice.pubkey_to_address.argtypes = [ctypes.c_int, ctypes.c_bool, ctypes.c_char_p]  # 012,comp,upub
+ice.pubkey_to_address.restype = ctypes.c_void_p
+#==============================================================================
+ice.privatekey_to_h160.argtypes = [ctypes.c_int, ctypes.c_bool, ctypes.c_char_p, ctypes.c_char_p]  # 012,comp,pvk,ret
+#==============================================================================
+ice.privatekey_loop_h160.argtypes = [ctypes.c_ulonglong, ctypes.c_int, ctypes.c_bool, ctypes.c_char_p, ctypes.c_char_p]  # num,012,comp,pvk,ret
+#==============================================================================
+ice.privatekey_loop_h160_sse.argtypes = [ctypes.c_ulonglong, ctypes.c_int, ctypes.c_bool, ctypes.c_char_p, ctypes.c_char_p]  # num,012,comp,pvk,ret
+#==============================================================================
+ice.pubkey_to_h160.argtypes = [ctypes.c_int, ctypes.c_bool, ctypes.c_char_p, ctypes.c_char_p]  # 012,comp,upub,ret
+#==============================================================================
+ice.pbkdf2_hmac_sha512_dll.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int] # ret, words, len
+#==============================================================================
+ice.pbkdf2_hmac_sha512_list.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_ulonglong, ctypes.c_int, ctypes.c_ulonglong] # ret,words,len,mnem_size,total 
+#==============================================================================
+ice.pub_endo1.argtypes = [ctypes.c_char_p, ctypes.c_char_p]  # upub,ret
+#==============================================================================
+ice.pub_endo2.argtypes = [ctypes.c_char_p, ctypes.c_char_p]  # upub,ret
+#==============================================================================
+ice.pubkey_isvalid.argtypes = [ctypes.c_char_p] #upub
+ice.pubkey_isvalid.restype = ctypes.c_bool #True or False
+#==============================================================================
+ice.b58_encode.argtypes = [ctypes.c_char_p]  # _h
+ice.b58_encode.restype = ctypes.c_void_p
+#==============================================================================
+ice.b58_decode.argtypes = [ctypes.c_char_p]  # addr
+ice.b58_decode.restype = ctypes.c_void_p
+#==============================================================================
+ice.bech32_address_decode.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_char_p]  # coin,b32_addr,h160
+#==============================================================================
+ice.get_hmac_sha512.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p] # k, klen, mess, mess_len, ret
+#==============================================================================
+ice.get_sha512.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p] # input, len, ret
+#==============================================================================
+ice.rmd160.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p] # input, len, ret
+#==============================================================================
+ice.hash160.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p] # input, len, ret
+#==============================================================================
+ice.mnem_to_masternode.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_char_p] # words, len, ret
+#==============================================================================
+ice.create_valid_mnemonics.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_int]  # rbytes,len, lang
+ice.create_valid_mnemonics.restype = ctypes.c_void_p
+#==============================================================================
+ice.get_sha256.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p] # input, len, ret
+#==============================================================================
+ice.get_sha256_iter.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p, ctypes.c_ulonglong] # input, len, ret, iter
+#==============================================================================
+ice.create_baby_table.argtypes = [ctypes.c_ulonglong, ctypes.c_ulonglong, ctypes.c_char_p] # start,end,ret
+#==============================================================================
+ice.point_addition.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p] # upub1,upub2,ret
+#==============================================================================
+ice.point_subtraction.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p] # upub1,upub2,ret
+#==============================================================================
+ice.point_loop_subtraction.argtypes = [ctypes.c_ulonglong, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p] # k,upub1,upub2,ret
+#==============================================================================
+ice.point_loop_addition.argtypes = [ctypes.c_ulonglong, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p] # k,upub1,upub2,ret
+#==============================================================================
+ice.point_vector_addition.argtypes = [ctypes.c_ulonglong, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p] # num,upubs1,upubs2,ret
+#==============================================================================
+ice.point_sequential_increment_P2.argtypes = [ctypes.c_ulonglong, ctypes.c_char_p, ctypes.c_char_p] # num,upub1,ret
+#==============================================================================
+ice.point_sequential_increment_P2_mcpu.argtypes = [ctypes.c_ulonglong, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p] # num,upub1,mcpu,ret
+#==============================================================================
+ice.point_sequential_increment_P2X_mcpu.argtypes = [ctypes.c_ulonglong, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p] # num,upub1,mcpu,retX
+#==============================================================================
+ice.point_sequential_increment.argtypes = [ctypes.c_ulonglong, ctypes.c_char_p, ctypes.c_char_p] # num,upub1,ret
+#==============================================================================
+ice.point_sequential_decrement.argtypes = [ctypes.c_ulonglong, ctypes.c_char_p, ctypes.c_char_p] # num,upub1,ret
+#==============================================================================
+ice.pubkeyxy_to_ETH_address.argtypes = [ctypes.c_char_p] # upub_xy
+ice.pubkeyxy_to_ETH_address.restype = ctypes.c_void_p
+#==============================================================================
+ice.pubkeyxy_to_ETH_address_bytes.argtypes = [ctypes.c_char_p, ctypes.c_char_p] # upub_xy, ret
+#==============================================================================
+ice.privatekey_to_ETH_address.argtypes = [ctypes.c_char_p] # pvk
+ice.privatekey_to_ETH_address.restype = ctypes.c_void_p
+#==============================================================================
+ice.privatekey_to_ETH_address_bytes.argtypes = [ctypes.c_char_p, ctypes.c_char_p] # pvk, ret
+#==============================================================================
+ice.privatekey_group_to_ETH_address.argtypes = [ctypes.c_char_p, ctypes.c_int] # pvk, m
+ice.privatekey_group_to_ETH_address.restype = ctypes.c_void_p
+#==============================================================================
+ice.privatekey_group_to_ETH_address_bytes.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p] # pvk,m,ret
+#==============================================================================
+ice.init_P2_Group.argtypes = [ctypes.c_char_p] # upub
+#==============================================================================
+ice.free_memory.argtypes = [ctypes.c_void_p] # pointer
+#==============================================================================
+ice.bloom_check_add.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_int, ctypes.c_ulonglong, ctypes.c_ubyte, ctypes.c_char_p] #buff, len, 0_1, _bits, _hashes, _bf
+ice.bloom_check_add.restype = ctypes.c_int
+#==============================================================================
+ice.bloom_batch_add.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_int, ctypes.c_int, ctypes.c_ulonglong, ctypes.c_ubyte, ctypes.c_char_p] #chunk, buff, len, 0_1, _bits, _hashes, _bf
+#==============================================================================
+ice.bloom_check_add_mcpu.argtypes = [ctypes.c_void_p, ctypes.c_ulonglong, ctypes.c_char_p, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_ulonglong, ctypes.c_ubyte, ctypes.c_char_p] #buff, num_items, found_array, len, mcpu, 0_1, _bits, _hashes, _bf
+#==============================================================================
+ice.test_bit_set_bit.argtypes = [ctypes.c_char_p, ctypes.c_ulonglong, ctypes.c_int] #_bf, _bits, 0_1
+#==============================================================================
+ice.create_bsgs_bloom_mcpu.argtypes = [ctypes.c_int, ctypes.c_ulonglong, ctypes.c_ulonglong, ctypes.c_ubyte, ctypes.c_char_p] #mcpu, num_items, _bits, _hashes, _bf
+#==============================================================================
+ice.bsgs_2nd_check_prepare.argtypes = [ctypes.c_ulonglong] # bP_elem
+#==============================================================================
+ice.dump_bsgs_state.argtypes = [ctypes.c_char_p, ctypes.c_bool] # binary_dump_file_out, verbose
+#==============================================================================
+ice.load_bsgs_state.argtypes = [ctypes.c_char_p, ctypes.c_bool] # binary_dump_file_in, verbose
+#==============================================================================
+ice.bsgs_2nd_check.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p] # upub, z1, ret
+ice.bsgs_2nd_check.restype = ctypes.c_bool #True or False
+#==============================================================================
+ice.bsgs_2nd_check_mcpu.argtypes = [ctypes.c_void_p, ctypes.c_ulonglong, ctypes.c_int, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p] # buff, num_items, mcpu, z1, ret, found_array
+#==============================================================================
+ice.Load_data_to_memory.argtypes = [ctypes.c_char_p, ctypes.c_bool] #sorted_bin_file_h160, verbose
+#==============================================================================
+ice.check_collision.argtypes = [ctypes.c_char_p] #h160
+ice.check_collision.restype = ctypes.c_bool #True or False
+#==============================================================================
+ice.check_collision_mcpu.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_int, ctypes.c_char_p] #h160_array, num_items, mcpu, found_array
+#==============================================================================
+ice.xor_filter_add.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_char_p] #buff, len, _bits, _hashes, _xf
+#==============================================================================
+ice.xor_filter_check.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_char_p] #buff, len, _bits, _hashes, _xf
+ice.xor_filter_check.restype = ctypes.c_int
+#==============================================================================
+ice.xor_filter_check_mcpu.argtypes = [ctypes.c_void_p, ctypes.c_ulonglong, ctypes.c_int, ctypes.c_int, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_char_p, ctypes.c_char_p] #buff, num_items, len, mcpu, _bits, _hashes, _xf, found_array
+#==============================================================================
+ice.bsgs_xor_create_mcpu.argtypes = [ctypes.c_int, ctypes.c_ulonglong, ctypes.c_uint64, ctypes.c_uint8, ctypes.c_char_p] #mcpu, total_entries, _bits, _hashes, _xf
+
+ice.init_secp256_lib()
+#==============================================================================
+###############################################################################
+
+###############################################################################
+#==============================================================================
+def version():
+    ice.version()   
+#==============================================================================
+def _scalar_multiplication(pvk_int):
+    ''' Integer value passed to function. 65 bytes uncompressed pubkey output '''
+    res = (b'\x00') * 65
+    pass_int_value = fl(pvk_int).encode('utf8')
+    ice.scalar_multiplication(pass_int_value, res)
+    return res
+def scalar_multiplication(pvk_int):
+    if pvk_int < 0: pvk_int = N+pvk_int
+    res = _scalar_multiplication(pvk_int)
+    return bytes(bytearray(res))
+#==============================================================================
+def _scalar_multiplications(pvk_int_list):
+    ''' Integer list passed to function. 65*len bytes uncompressed pubkey output. No Zero Point handling '''
+    sz = len(pvk_int_list)
+    res = (b'\x00') * (65 * sz)
+    pvks = b''.join(pvk_int_list)
+    ice.scalar_multiplications(pvks, sz, res)
+    return res
+def scalar_multiplications(pvk_int_list):
+    pvk_int_list = [bytes.fromhex(fl(N+i)) if i < 0 else bytes.fromhex(fl(i)) for i in pvk_int_list]
+    res = _scalar_multiplications(pvk_int_list)
+    return bytes(bytearray(res))
+#==============================================================================
+def _point_multiplication(pubkey_bytes, kk):
+    ''' Input Point and Integer value passed to function. 65 bytes uncompressed pubkey output '''
+    res = (b'\x00') * 65
+    bytes_value = bytes.fromhex(hex(kk)[2:].zfill(64))  # strict 32 bytes scalar
+    ice.point_multiplication(pubkey_bytes, bytes_value, res)
+    return res
+def point_multiplication(P, k):
+    if type(P) == int: k,P = P,k
+    res = _point_multiplication(P, k)
+    return bytes(bytearray(res))
+#==============================================================================
+def point_division(P, k):
+    ''' Input Point and Integer value passed to function. 65 bytes uncompressed pubkey output '''
+    kk = inv(k)
+    res = point_multiplication(P, kk)
+    return bytes(bytearray(res))
+#==============================================================================
+def _get_x_to_y(x_hex, is_even):
+    ''' Input x_hex encoded as bytes and bool is_even. 32 bytes y of point output '''
+    res = (b'\x00') * 32
+    ice.get_x_to_y(x_hex.encode('utf8'), is_even, res)
+    return res
+def get_x_to_y(x_hex, is_even):
+    res = _get_x_to_y(x_hex, is_even)
+    return bytes(bytearray(res))
+#==============================================================================
+def _point_increment(pubkey_bytes):
+    res = (b'\x00') * 65
+    ice.point_increment(pubkey_bytes, res)
+    return res
+def point_increment(pubkey_bytes):
+    res = _point_increment(pubkey_bytes)
+    return bytes(bytearray(res))
+#==============================================================================
+def _point_negation(pubkey_bytes):
+    res = (b'\x00') * 65
+    ice.point_negation(pubkey_bytes, res)
+    return res
+def point_negation(pubkey_bytes):
+    res = _point_negation(pubkey_bytes)
+    return bytes(bytearray(res))
+#==============================================================================
+def _point_doubling(pubkey_bytes):
+    res = (b'\x00') * 65
+    ice.point_doubling(pubkey_bytes, res)
+    return res
+def point_doubling(pubkey_bytes):
+    res = _point_doubling(pubkey_bytes)
+    return bytes(bytearray(res))
+#==============================================================================
+def init_P2_Group(pubkey_bytes):
+    ice.init_P2_Group(pubkey_bytes)
+#==============================================================================
+def privatekey_to_coinaddress(coin_type, addr_type, iscompressed, pvk_int):
+    # type = 0 [p2pkh],  1 [p2sh],  2 [bech32]
+    if pvk_int < 0: pvk_int = N+pvk_int
+    pass_int_value = fl(pvk_int).encode('utf8')
+    res = ice.privatekey_to_coinaddress(coin_type, addr_type, iscompressed, pass_int_value)
+    addr = (ctypes.cast(res, ctypes.c_char_p).value).decode('utf8')
+    ice.free_memory(res)
+    return addr
+#==============================================================================
+def pubkey_to_coinaddress(coin_type, addr_type, iscompressed, pubkey_bytes):
+    # type = 0 [p2pkh],  1 [p2sh],  2 [bech32]
+    res = ice.pubkey_to_coinaddress(coin_type, addr_type, iscompressed, pubkey_bytes)
+    addr = (ctypes.cast(res, ctypes.c_char_p).value).decode('utf8')
+    ice.free_memory(res)
+    return addr
+#==============================================================================
+def privatekey_to_address(addr_type, iscompressed, pvk_int):
+    # type = 0 [p2pkh],  1 [p2sh],  2 [bech32]
+    if pvk_int < 0: pvk_int = N+pvk_int
+    pass_int_value = fl(pvk_int).encode('utf8')
+    res = ice.privatekey_to_address(addr_type, iscompressed, pass_int_value)
+    addr = (ctypes.cast(res, ctypes.c_char_p).value).decode('utf8')
+    ice.free_memory(res)
+    return addr
+#==============================================================================
+def hash_to_address(addr_type, iscompressed, hash160_bytes):
+    # type = 0 [p2pkh],  1 [p2sh],  2 [bech32]
+    res = ice.hash_to_address(addr_type, iscompressed, hash160_bytes)
+    addr = (ctypes.cast(res, ctypes.c_char_p).value).decode('utf8')
+    ice.free_memory(res)
+    return addr
+#==============================================================================
+def pubkey_to_address(addr_type, iscompressed, pubkey_bytes):
+    # type = 0 [p2pkh],  1 [p2sh],  2 [bech32]
+    res = ice.pubkey_to_address(addr_type, iscompressed, pubkey_bytes)
+    addr = (ctypes.cast(res, ctypes.c_char_p).value).decode('utf8')
+    ice.free_memory(res)
+    return addr
+#==============================================================================
+def pubkey_to_p2wsh_address(pubkey_bytes):
+    # [bech32 p2wsh]
+    res = ice.pubkey_to_p2wsh_address(pubkey_bytes)
+    addr = (ctypes.cast(res, ctypes.c_char_p).value).decode('utf8')
+    ice.free_memory(res)
+    return addr
+#==============================================================================
+def _privatekey_to_h160(addr_type, iscompressed, pvk_int):
+    # type = 0 [p2pkh],  1 [p2sh],  2 [bech32]
+    if pvk_int < 0: pvk_int = N+pvk_int
+    pass_int_value = fl(pvk_int).encode('utf8')
+    res = (b'\x00') * 20
+    ice.privatekey_to_h160(addr_type, iscompressed, pass_int_value, res)
+    return res
+def privatekey_to_h160(addr_type, iscompressed, pvk_int):
+    res = _privatekey_to_h160(addr_type, iscompressed, pvk_int)
+    return bytes(bytearray(res))
+#==============================================================================
+def _privatekey_loop_h160(num, addr_type, iscompressed, pvk_int):
+    # type = 0 [p2pkh],  1 [p2sh],  2 [bech32]
+    if pvk_int < 0: pvk_int = N+pvk_int
+    pass_int_value = fl(pvk_int).encode('utf8')
+    res = (b'\x00') * (20 * num)
+    ice.privatekey_loop_h160(num, addr_type, iscompressed, pass_int_value, res)
+    return res
+def privatekey_loop_h160(num, addr_type, iscompressed, pvk_int):
+    if num <= 0: num = 1
+    res = _privatekey_loop_h160(num, addr_type, iscompressed, pvk_int)
+    return bytes(bytearray(res))
+#==============================================================================
+def _privatekey_loop_h160_sse(num, addr_type, iscompressed, pvk_int):
+    # type = 0 [p2pkh],  1 [p2sh],  2 [bech32]
+    if pvk_int < 0: pvk_int = N+pvk_int
+    pass_int_value = fl(pvk_int).encode('utf8')
+    res = (b'\x00') * (20 * num)
+    ice.privatekey_loop_h160_sse(num, addr_type, iscompressed, pass_int_value, res)
+    return res
+def privatekey_loop_h160_sse(num, addr_type, iscompressed, pvk_int):
+    if num <= 0: num = 1
+    res = _privatekey_loop_h160_sse(num, addr_type, iscompressed, pvk_int)
+    return bytes(bytearray(res))
+#==============================================================================
+def _pubkey_to_h160(addr_type, iscompressed, pubkey_bytes):
+    # type = 0 [p2pkh],  1 [p2sh],  2 [bech32]
+    res = (b'\x00') * 20
+    ice.pubkey_to_h160(addr_type, iscompressed, pubkey_bytes, res)
+    return res
+def pubkey_to_h160(addr_type, iscompressed, pubkey_bytes):
+    res = _pubkey_to_h160(addr_type, iscompressed, pubkey_bytes)
+    return bytes(bytearray(res))
+#==============================================================================
+def _pub_endo1(pubkey_bytes):
+    res = (b'\x00') * 65
+    ice.pub_endo1(pubkey_bytes, res)
+    return res
+def pub_endo1(pubkey_bytes):
+    res = _pub_endo1(pubkey_bytes)
+    return bytes(bytearray(res))
+#==============================================================================
+def _pub_endo2(pubkey_bytes):
+    res = (b'\x00') * 65
+    ice.pub_endo2(pubkey_bytes, res)
+    return res
+def pub_endo2(pubkey_bytes):
+    res = _pub_endo2(pubkey_bytes)
+    return bytes(bytearray(res))
+#==============================================================================
+def pubkey_isvalid(pubkey_bytes):
+    ''' check if the pubkey is on the curve '''
+    is_valid = ice.pubkey_isvalid(pubkey_bytes)
+    return is_valid
+#==============================================================================
+def one_to_6pubkey(pubkey_bytes):
+    # Pubkey = [x,y]  [x*beta%p, y]  [x*beta2%p, y] [x,p-y]  [x*beta%p, p-y]  [x*beta2%p, p-y]
+    # beta = 0x7ae96a2b657c07106e64479eac3434e99cf0497512f58995c1396c28719501ee
+    # beta2 = 0x851695d49a83f8ef919bb86153cbcb16630fb68aed0a766a3ec693d68e6afa40      # beta*beta
+    P1 = pubkey_bytes
+    P2 = pub_endo1(pubkey_bytes)
+    P3 = pub_endo2(pubkey_bytes)
+    P4 = point_negation(pubkey_bytes)
+    P5 = pub_endo1(P4)
+    P6 = pub_endo2(P4)
+    return P1, P2, P3, P4, P5, P6
+#==============================================================================
+def one_to_6privatekey(pvk_int):
+    lmda = 0x5363ad4cc05c30e0a5261c028812645a122e22ea20816678df02967c1b23bd72
+    lmda2 = 0xac9c52b33fa3cf1f5ad9e3fd77ed9ba4a880b9fc8ec739c2e0cfc810b51283ce      # lmda*lmda
+    #print('PVK1 : ', hex(pvk_int)[2:].zfill(64))
+    #print('PVK2 : ', hex(pvk_int*lmda%N)[2:].zfill(64))
+    #print('PVK3 : ', hex(pvk_int*lmda2%N)[2:].zfill(64))
+    #print('PVK4 : ', hex(N-pvk_int)[2:].zfill(64))
+    #print('PVK5 : ', hex(N-pvk_int*lmda%N)[2:].zfill(64))
+    #print('PVK6 : ', hex(N-pvk_int*lmda2%N)[2:].zfill(64))
+    return pvk_int, pvk_int*lmda%N, pvk_int*lmda2%N, N-pvk_int, N-pvk_int*lmda%N, N-pvk_int*lmda2%N
+#==============================================================================
+def b58py(data):
+    B58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+    if data[0] == 0:
+        return "1" + b58py(data[1:])
+
+    x = sum([v * (256 ** i) for i, v in enumerate(data[::-1])])
+    ret = ""
+    while x > 0:
+        ret = B58[x % 58] + ret
+        x = x // 58
+        
+    return ret
+#==============================================================================
+def b58_encode(inp_bytes):
+    res = ice.b58_encode(inp_bytes, len(inp_bytes))
+    addr = (ctypes.cast(res, ctypes.c_char_p).value).decode('utf8')
+    ice.free_memory(res)
+    return addr
+#==============================================================================
+def b58_decode(inp):
+    res = ice.b58_decode(inp.encode("utf-8"))
+    addr = (ctypes.cast(res, ctypes.c_char_p).value).decode('utf8')
+    ice.free_memory(res)
+    return addr
+#==============================================================================
+def bech32_address_decode(addr, coin_type=0):
+    ''' Input address in String format. Output h160 in hex string format
+    [Note] p2wsh = bech32(sha256(21 + pubkey + ac)). So Decoding it not Needed '''
+    if len(addr) > 50:
+        h160 = (b'\x00') * 32   # Bech32 p2wsh case
+    else: h160 = (b'\x00') * 20 # Bech32 p2wpkh case
+    ice.bech32_address_decode(coin_type, addr.encode("utf-8"), h160)
+    return bytes(bytearray(h160)).hex()
+#==============================================================================
+def address_to_h160(p2pkh):
+    ''' Input address in String format. Output h160 in hex string format'''
+    h1 = b58_decode(p2pkh)
+    return h1[2:-8]
+#==============================================================================
+def create_burn_address(vanity = 'iceLand', filler = 'x'):
+    # create_burn_address('ADayWiLLcomeWheniceLandisGoingToSoLvebitCoinPuzzLe', 'X')
+    out = []
+    bs58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+    for i in vanity:
+        if i not in bs58:
+            return "invalid char found in vanity --> : " + i
+    vanity = [vanity[i:i+25] for i in range(0,len(vanity),25)] # For longer text make many address
+    for t in vanity:
+        s = t.ljust(30, filler) if t[0] == '1' else ('1'+t).ljust(30, filler) + '111'
+        h = address_to_h160(s)
+        out.append(hash_to_address(0, True, bytes.fromhex(h)))
+    if len(out) == 1: return out[0]
+    else:    return out
+#==============================================================================
+def btc_wif_to_pvk_hex(wif):
+    pvk = ''
+    if wif[0] == '5':
+        pvk = b58_decode(wif)[2:-8]
+    elif wif[0] in ['L', 'K']:
+        pvk = b58_decode(wif)[2:-10]
+    else: print('[Error] Incorrect WIF Key')
+    return pvk
+#==============================================================================
+def btc_wif_to_pvk_int(wif):
+    pvk = ''
+    pvk_hex = btc_wif_to_pvk_hex(wif)
+    if pvk_hex != '': pvk = int(pvk_hex, 16)
+    return pvk
+#==============================================================================
+def btc_pvk_to_wif(pvk, is_compressed=True):
+    ''' Input Privatekey can in any 1 of these [Integer] [Hex] [Bytes] form'''
+    inp = ''
+    suff = '01' if is_compressed == True else ''
+    if type(pvk) in [int, str]: inp = bytes.fromhex('80' + fl(pvk) + suff)
+    elif type(pvk) == bytes: inp = b'\x80' + fl(pvk) + bytes.fromhex(suff)
+    else: print("[Error] Input Privatekey format [Integer] [Hex] [Bytes] allowed only")
+    if inp != '':
+        res = get_sha256(inp)
+        res2 = get_sha256(res)
+        return b58_encode(inp + res2[:4])
+    else: return inp
+#==============================================================================
+def checksum(inp):
+    ''' Input string output double sha256 checksum 4 bytes'''
+    res = get_sha256(inp)
+    res2 = get_sha256(res)
+    return res2[:4]
+#==============================================================================
+def chunks(s, sz=65):
+    for start in range(0, len(s), sz):
+        yield s[start : start + sz]
+#==============================================================================
+def inv(a):
+    return pow(a, N - 2, N)
+#==============================================================================
+def msg_magic(message):
+    lm = len(message)
+    a = ((lm.to_bytes(1, 'little') if lm < 0xFD else b'\xFD' + lm.to_bytes(2, 'little')) 
+         if lm <= 0xFFFF else b'\xFE' + lm.to_bytes(4, 'little')) if lm <=0xFFFFFFFF else b'\xFF' + lm.to_bytes(8, 'little')
+    return b'\x18Bitcoin Signed Message:\n' + a + message.encode('utf-8')
+#==============================================================================
+def verify_message(address, signature, message):
+    out = _verify_message(address, signature, message)
+    if out == False:
+        print(f"Message Failed to verify from Address: {address}")
+    else:
+        r, s, z, is_compress, RP, pubkey = out
+        print(f'Rpoint: {RP.hex()}')
+        print(f'r : {r:064x}')
+        print(f's : {s:064x}')
+        print(f'z : {z:064x}')
+        print(f'PubKey : {pubkey}')
+        print(f'Address : {address}')
+        print('\nsignature is Valid and Address is Verified.\n')
+        print('-----BEGIN BITCOIN SIGNED MESSAGE-----')
+        print(message)
+        print('-----BEGIN BITCOIN SIGNATURE-----')
+        print(address)
+        print(signature)
+        print('-----END BITCOIN SIGNATURE-----')
+#==============================================================================
+
+def _verify_message(address, signature, message):
+    """ Follow BIP-0137 for the specifications """
+    sig = base64.b64decode(signature)
+    rcid, r, s = sig[0], int.from_bytes(sig[1:33], 'big'), int.from_bytes(sig[33:], 'big')
+    msb = msg_magic(message)
+    z = int.from_bytes(get_sha256(get_sha256(msb)), 'big')
+    #print(f'r : {hex(r)[2:]}')
+    #print(f's : {hex(s)[2:]}')
+    #print(f'z : {hex(z)[2:]}')
+        
+    RPF = lambda prefix, r: pub2upub(prefix + hex(r)[2:].zfill(64))
+    zdr = (z * inv(r)) % N
+    sL = [(i * inv(r)) % N for i in [s, -s%N] ]
+    RL = [RPF('02', r), RPF('03', r), RPF('02', -r%N), RPF('03', -r%N)]
+    aD = {'1':0, '3':1, 'b':2}
+    is_compressed = False if rcid >= 27 and rcid <= 30 else True
+
+    #print(f'is_compressed={is_compressed}')
+    
+    for sdr in sL:
+        #print(f'sdr={hex(sdr)}')
+        for RP in RL:
+            #print(f'RP={RP.hex()}')
+            FF = point_subtraction( point_multiplication(RP, sdr),
+                                        scalar_multiplication(zdr) )
+            #print(f'FF={point_to_cpub(FF)}')
+            if address == pubkey_to_address(aD[address[0]], is_compressed, FF):
+                #print(f'Matched {address}')
+                if is_compressed:
+                    return r, s, z, is_compressed, RP, point_to_cpub(FF)
+                else:
+                    return r, s, z, is_compressed, RP, FF.hex()
+        return False
+#==============================================================================
+def fl(sstr, length=64):
+    ''' Fill input to exact 32 bytes. If input is int or str the return is str. if input is bytes return is bytes'''
+    if type(sstr) == int: fixed = hex(sstr%N)[2:].zfill(length)
+    elif type(sstr) == str: fixed = sstr[2:].zfill(length) if sstr[:2].lower() == '0x' else sstr.zfill(length)
+    elif type(sstr) == bytes: fixed = (b'\x00') * (32 - len(sstr)) + sstr
+    else: print("[Error] Input format [Integer] [Hex] [Bytes] allowed only. Detected : ", type(sstr))
+    return fixed
+#==============================================================================
+def create_valid_mnemonics(strength = 128, lang = MNEM_EN):
+    # valid_entropy_bits = [128, 160, 192, 224, 256]
+    if strength not in [128, 160, 192, 224, 256]: 
+        return 'Invalid strength'
+    rbytes = os.urandom(strength // 8)
+    res = ice.create_valid_mnemonics(rbytes, len(rbytes), lang)
+    mnem = (ctypes.cast(res, ctypes.c_char_p).value).decode('utf8')
+    ice.free_memory(res)
+    return mnem
+#==============================================================================
+def pbkdf2_hmac_sha512_dll(words):
+    seed_bytes = (b'\x00') * 64
+#    words = 'good push broken people salad bar mad squirrel joy dismiss merge jeans token wear boring manual doll near sniff turtle sunset lend invest foil'
+    ice.pbkdf2_hmac_sha512_dll(seed_bytes, words.encode("utf-8"), len(words))
+    return bytes(bytearray(seed_bytes))
+#==============================================================================
+def pbkdf2_hmac_sha512_list(words_list):
+    ''' strength is [12, 18, 24]. words_list is a list of strings with each line having valid mnemonics'''
+    wl = len(words_list)
+    strength = len(words_list[0].split())
+    words = ' '.join(words_list)
+    seed_bytes = (b'\x00') * (64 * wl)
+#    words = 'good push broken people salad bar mad squirrel joy dismiss merge jeans token wear boring manual doll near sniff turtle sunset lend invest foil'
+    ice.pbkdf2_hmac_sha512_list(seed_bytes, words.encode("utf-8"), len(words), strength, wl)
+    return bytes(bytearray(seed_bytes))
+#==============================================================================
+def mnemonics_to_bip32masternode(words):
+    digest_bytes = (b'\x00') * 64
+    ice.mnem_to_masternode(words.encode("utf-8"), len(words), digest_bytes)
+    key, chain_code = digest_bytes[:32], digest_bytes[32:]
+    return key, chain_code
+#==============================================================================
+def bip39seed_to_bip32masternode(seed):
+    h = hmac_sha512(b'Bitcoin seed', seed)
+    key, chain_code = h[:32], h[32:]
+    return key, chain_code
+#==============================================================================
+def _p2i(x = "44'"):
+    if "'" in x:    return 0x80000000 + int(x[:-1])
+    else:           return int(x)
+    
+def _parse_derivation_path(str_derivation_path="m/44'/60'/0'/0/0"):      # 60' is for ETH 0' is for BTC
+    path = []
+    sdp = str_derivation_path.replace(" ", "")
+    if sdp[0:2] != 'm/':
+        raise ValueError("Can't recognize derivation path. It should look like \"m/44'/0'/0'/0\".")
+        
+    for i in sdp.lstrip('m/').split('/'):
+        path.append(_p2i(i))
+        
+    return [path] # return a list of list
+
+def parse_derivation_path(str_derivation_path_range="m/44'/60'/0'/0/(0-5)"):      # 60' is for ETH 0' is for BTC
+    if str_derivation_path_range.count("(") == 0:   # No range, only single value
+        return _parse_derivation_path(str_derivation_path_range)
+    
+    def deplist(i = "(0-3)"):
+        if i[0] == '(':     # It is a range of values
+            flgh = False
+            if i[-1] == "'": 
+                flgh = True
+                dr = [int(x) for x in i.lstrip('(').rstrip(")'").split('-')]
+            else: 
+                dr = [int(x) for x in i.lstrip('(').rstrip(')').split('-')]
+             
+            return [str(i)+"'" if flgh else str(i) for i in range(dr[0], dr[1]+1)]   # +1 to include the last element
+    
+    sdp = str_derivation_path_range.replace(" ", "")
+    og = sdp.lstrip('m/').split('/')
+    path = [_p2i(x) for x in og[:-1]]        # Leaving last element of range childpath
+    
+    return path, deplist( og[-1] ) # A tuple of (first 4 values and list for last value range)
+#==============================================================================
+def derive_bip32childkey(parent_key, parent_chain_code, i):
+    assert len(parent_key) == 32
+    assert len(parent_chain_code) == 32
+    k = parent_chain_code
+    if (i & 0x80000000) != 0:
+        key = b'\x00' + parent_key
+    else:
+        key = bytes.fromhex(point_to_cpub(scalar_multiplication(int.from_bytes(parent_key, byteorder='big'))))
+    d = key + bytes.fromhex(hex(i)[2:].zfill(8))
+    while True:
+        h = hmac_sha512(k, d)
+        key, chain_code = h[:32], h[32:]
+        a = int.from_bytes(key, byteorder='big')
+        b = int.from_bytes(parent_key, byteorder='big')
+        key = (a + b) % N
+        if a < N and key != 0:
+            key = key.to_bytes(32, byteorder='big')
+            break
+        d = b'\x01' + h[32:] + bytes.fromhex(hex(i)[2:].zfill(8))
+    return key, chain_code
+#==============================================================================
+def bip39seed_to_privatekey(bip39seed, str_derivation_path = "m/44'/0'/0'/0/0"): # ' is Hardened otherwise Normal
+    # suports single "m/44'/0'/0'/0/0" and range of child "m/44'/0'/0'/0/(11-21)"
+    derivation_path = parse_derivation_path(str_derivation_path)
+    master_private_key, master_chain_code = bip39seed_to_bip32masternode(bip39seed)
+    private_key, chain_code = master_private_key, master_chain_code
+    
+    
+    for i in derivation_path[0]:    # All values for single case. In case of range Except last element.
+        # parent_fingerprint = fingerprint_from_pvk(int(private_key.hex(), 16))
+        # child_number_bytes = bytes.fromhex(hex(i)[2:])
+        # depth_byte : starts from 1 2 3 4 5
+        private_key, chain_code = derive_bip32childkey(private_key, chain_code, i)
+        
+    if len(derivation_path) == 2:   # check if range case 
+        pvklist = []
+        for i in derivation_path[1]:
+            # parent_fingerprint = fingerprint_from_pvk(int(private_key.hex(), 16))
+            # child_number_bytes = bytes.fromhex(hex(i)[2:])
+            # depth_byte = b'\05' # this one is Last
+            tpvk, _ = derive_bip32childkey(private_key, chain_code, _p2i(i))
+            pvklist.append(tpvk)
+        return pvklist                  # list of bytes
+    return private_key                  # bytes
+#==============================================================================
+def mnem_to_privatekey(words, str_derivation_path = "m/44'/0'/0'/0/0"): # ' is Hardened otherwise Normal
+    # suports single "m/44'/0'/0'/0/0" and range of child "m/44'/0'/0'/0/(11-21)"    
+    seed = pbkdf2_hmac_sha512_dll(words)
+    return bip39seed_to_privatekey(seed, str_derivation_path) # either bytes or list of bytes
+#==============================================================================
+def mnem_to_address(words, addr_type, iscompressed, str_derivation_path = "m/44'/0'/0'/0/0"): # ' is Hardened otherwise Normal
+    # suports single "m/44'/0'/0'/0/0" and range of child "m/44'/0'/0'/0/(11-21)"    
+    seed = pbkdf2_hmac_sha512_dll(words)
+    pvks = bip39seed_to_privatekey(seed, str_derivation_path) # either bytes or list of bytes
+    if type(pvks) == list:
+        return [privatekey_to_address(addr_type, iscompressed, int(line.hex(), 16)) for line in pvks]   # list of addresses
+    return privatekey_to_address(addr_type, iscompressed, int(pvks.hex(), 16)) # single address
+#==============================================================================
+def fingerprint_from_pvk(k): # input int key
+    return privatekey_to_h160(0, True, k)[:4]
+#==============================================================================
+def root_key(master_private_key, master_chain_code, version = '0488ade4'):
+    '''This same function can be modified for getting xprv, xpub of extended keys.
+    Need to return also the parent_fingerprint, child_number_bytes, depth_byte to use here
+    '''
+    version_bytes = bytes.fromhex(version)   # Mainnet [Private: '0488ade4'] [Public: '0488b21e']
+    key_bytes = b'\x00' + master_private_key
+    # version_bytes, depth_byte, parent_fingerprint, child_number_bytes, master_chain_code, key_bytes
+    inp = version_bytes + b'\x00' + b'\x00' * 4 + b'\x00' * 4 + master_chain_code + key_bytes
+    xp = b58_encode(inp + checksum(inp))
+    return xp
+#==============================================================================
+def hmac_sha512(key_bytes, message_bytes):
+    digest_bytes = (b'\x00') * 64
+    if type(key_bytes) == str: key_bytes = key_bytes.encode("utf-8")
+    if type(message_bytes) == str: message_bytes = message_bytes.encode("utf-8")
+    ice.get_hmac_sha512(key_bytes, len(key_bytes), message_bytes, len(message_bytes), digest_bytes)
+    return bytes(bytearray(digest_bytes))
+#==============================================================================
+def sha512(input_bytes):
+    digest_bytes = (b'\x00') * 64
+    if type(input_bytes) == str: input_bytes = input_bytes.encode("utf-8")
+    ice.get_sha512(input_bytes, len(input_bytes), digest_bytes)
+    return bytes(bytearray(digest_bytes))
+#==============================================================================
+def hash160(input_bytes):
+    digest_bytes = (b'\x00') * 20
+    if type(input_bytes) == str: input_bytes = input_bytes.encode("utf-8")
+    ice.hash160(input_bytes, len(input_bytes), digest_bytes)
+    return bytes(bytearray(digest_bytes))
+#==============================================================================
+def rmd160(input_bytes):
+    digest_bytes = (b'\x00') * 20
+    ice.rmd160(input_bytes, len(input_bytes), digest_bytes)
+    return bytes(bytearray(digest_bytes))
+#==============================================================================
+def get_sha256(input_bytes):
+    digest_bytes = (b'\x00') * 32
+    if type(input_bytes) == str: input_bytes = input_bytes.encode("utf-8")
+#    MiniKey example
+    ice.get_sha256(input_bytes, len(input_bytes), digest_bytes)
+    return bytes(bytearray(digest_bytes))
+#==============================================================================
+def get_sha256_iter(input_bytes, iteration = 1):
+    digest_bytes = (b'\x00') * 32
+    if type(input_bytes) == str: input_bytes = input_bytes.encode("utf-8")
+    ice.get_sha256_iter(input_bytes, len(input_bytes), digest_bytes, iteration)
+    return bytes(bytearray(digest_bytes))
+#==============================================================================
+def create_baby_table(start_value, end_value):
+    res = (b'\x00') * ((1+end_value-start_value) * 32)
+    ice.create_baby_table(start_value, end_value, res)
+    return bytes(bytearray(res))
+#==============================================================================
+def _point_addition(pubkey1_bytes, pubkey2_bytes):
+    res = (b'\x00') * 65
+    ice.point_addition(pubkey1_bytes, pubkey2_bytes, res)
+    return res
+def point_addition(pubkey1_bytes, pubkey2_bytes):
+    res = _point_addition(pubkey1_bytes, pubkey2_bytes)
+    return bytes(bytearray(res))
+#==============================================================================
+def _point_subtraction(pubkey1_bytes, pubkey2_bytes):
+    res = (b'\x00') * 65
+    ice.point_subtraction(pubkey1_bytes, pubkey2_bytes, res)
+    return res
+def point_subtraction(pubkey1_bytes, pubkey2_bytes):
+    res = _point_subtraction(pubkey1_bytes, pubkey2_bytes)
+    return bytes(bytearray(res))
+#==============================================================================
+def _point_loop_subtraction(num, pubkey1_bytes, pubkey2_bytes):
+    res = (b'\x00') * (65 * num)
+    ice.point_loop_subtraction(num, pubkey1_bytes, pubkey2_bytes, res)
+    return res
+def point_loop_subtraction(num, pubkey1_bytes, pubkey2_bytes):
+    ''' Continuously subtracting point2 into point1 in a loop of num times. 
+    Output is array of pubkeys P1-P2, P1-2P2, P1-3P2, P1-4P2....'''
+    if num <= 0: num = 1
+    res = _point_loop_subtraction(num, pubkey1_bytes, pubkey2_bytes)
+    return bytes(bytearray(res))
+#==============================================================================
+def _point_loop_addition(num, pubkey1_bytes, pubkey2_bytes):
+    res = (b'\x00') * (65 * num)
+    ice.point_loop_addition(num, pubkey1_bytes, pubkey2_bytes, res)
+    return res
+def point_loop_addition(num, pubkey1_bytes, pubkey2_bytes):
+    ''' Continuously adding point2 into point1 in a loop of num times. 
+    Output is array of pubkeys P1+P2, P1+2P2, P1+3P2, P1+4P2....'''
+    if num <= 0: num = 1
+    res = _point_loop_addition(num, pubkey1_bytes, pubkey2_bytes)
+    return bytes(bytearray(res))
+#==============================================================================
+def _point_vector_addition(num, pubkeys1_bytes, pubkeys2_bytes):
+    res = (b'\x00') * (65 * num)
+    ice.point_vector_addition(num, pubkeys1_bytes, pubkeys2_bytes, res)
+    return res
+def point_vector_addition(num, pubkeys1_bytes, pubkeys2_bytes):
+    ''' Adding two array of points of equal length. '''
+    if num <= 0: num = 1
+    res = _point_vector_addition(num, pubkeys1_bytes, pubkeys2_bytes)
+    return bytes(bytearray(res))
+#==============================================================================
+def _point_sequential_increment_P2(num, pubkey1_bytes):
+    res = (b'\x00') * (65 * num)
+    ice.point_sequential_increment_P2(num, pubkey1_bytes, res)
+    return res
+def point_sequential_increment_P2(num, pubkey1_bytes):
+    ''' Use init_P2_Group(P2) to initialize it just once.
+    This is the fastest implementation to add point P2 in the given Point sequentially.'''
+    if num <= 0: num = 1
+    res = _point_sequential_increment_P2(num, pubkey1_bytes)
+    return bytes(bytearray(res))
+#==============================================================================
+def _point_sequential_increment_P2_mcpu(num, pubkey1_bytes, mcpu):
+    res = (b'\x00') * (65 * num)
+    ice.point_sequential_increment_P2_mcpu(num, pubkey1_bytes, mcpu, res)
+    return res
+def point_sequential_increment_P2_mcpu(num, pubkey1_bytes, mcpu=os.cpu_count()):
+    ''' Use init_P2_Group(P2) to initialize it just once.
+    This is the fastest multi CPU implementation to add point P2 in the given Point sequentially. Threads are Not optimised yet'''
+    if num <= 0: num = 1
+    res = _point_sequential_increment_P2_mcpu(num, pubkey1_bytes, mcpu)
+    return bytes(bytearray(res))
+#==============================================================================
+def _point_sequential_increment_P2X_mcpu(num, pubkey1_bytes, mcpu):
+    res = (b'\x00') * (32 * num)  # only X is returned from pubkeys
+    ice.point_sequential_increment_P2X_mcpu(num, pubkey1_bytes, mcpu, res)
+    return res
+def point_sequential_increment_P2X_mcpu(num, pubkey1_bytes, mcpu=os.cpu_count()):
+    ''' Use init_P2_Group(P2) to initialize it just once.
+    This is the fastest multi CPU implementation to add point P2 in the given Point sequentially. Threads are Not optimised yet'''
+    if num <= 0: num = 1
+    res = _point_sequential_increment_P2X_mcpu(num, pubkey1_bytes, mcpu)
+    return bytes(bytearray(res))
+#==============================================================================
+def _point_sequential_increment(num, pubkey1_bytes):
+    res = (b'\x00') * (65 * num)
+    ice.point_sequential_increment(num, pubkey1_bytes, res)
+    return res
+def point_sequential_increment(num, pubkey1_bytes):
+    ''' This is the fastest implementation using G'''
+    if num <= 0: num = 1
+    res = _point_sequential_increment(num, pubkey1_bytes)
+    return bytes(bytearray(res))
+#==============================================================================
+def _point_sequential_decrement(num, pubkey1_bytes):
+    res = (b'\x00') * (65 * num)
+    ice.point_sequential_decrement(num, pubkey1_bytes, res)
+    return res
+def point_sequential_decrement(num, pubkey1_bytes):
+    ''' This is the fastest implementation using -G.'''
+    if num <= 0: num = 1
+    res = _point_sequential_decrement(num, pubkey1_bytes)
+    return bytes(bytearray(res))
+#==============================================================================
+def pubkey_to_ETH_address(pubkey_bytes):
+    ''' 65 Upub bytes input. Output is 20 bytes ETH address lowercase with 0x as hex string'''
+    xy = pubkey_bytes[1:]
+    res = ice.pubkeyxy_to_ETH_address(xy)
+    addr = (ctypes.cast(res, ctypes.c_char_p).value).decode('utf8')
+    ice.free_memory(res)
+    return '0x'+addr
+#==============================================================================
+def _pubkey_to_ETH_address_bytes(xy):
+    res = (b'\x00') * 20
+    ice.pubkeyxy_to_ETH_address_bytes(xy, res)
+    return res
+def pubkey_to_ETH_address_bytes(pubkey_bytes):
+    ''' 65 Upub bytes input. Output is 20 bytes ETH address lowercase without 0x'''
+    xy = pubkey_bytes[1:]
+    res = _pubkey_to_ETH_address_bytes(xy)
+    return bytes(bytearray(res))
+#==============================================================================
+def privatekey_to_ETH_address(pvk_int):
+    ''' Privatekey Integer value passed to function. Output is 20 bytes ETH address lowercase with 0x as hex string'''
+    if pvk_int < 0: pvk_int = N+pvk_int
+    pass_int_value = fl(pvk_int).encode('utf8')
+    res = ice.privatekey_to_ETH_address(pass_int_value)
+    addr = (ctypes.cast(res, ctypes.c_char_p).value).decode('utf8')
+    ice.free_memory(res)
+    return '0x'+addr
+#==============================================================================
+def _privatekey_to_ETH_address_bytes(pass_int_value):
+    res = (b'\x00') * 20
+    ice.privatekey_to_ETH_address_bytes(pass_int_value, res)
+    return res
+def privatekey_to_ETH_address_bytes(pvk_int):
+    ''' Privatekey Integer value passed to function. Output is 20 bytes ETH address lowercase without 0x'''
+    if pvk_int < 0: pvk_int = N+pvk_int
+    pass_int_value = fl(pvk_int).encode('utf8')
+    res = _privatekey_to_ETH_address_bytes(pass_int_value)
+    return bytes(bytearray(res))
+#==============================================================================
+def privatekey_group_to_ETH_address(pvk_int, m):
+    ''' Starting Privatekey Integer value passed to function as pvk_int.
+    Integer m is, how many times sequential increment is done from the starting key.
+    Output is bytes 20*m of ETH address lowercase without 0x as hex string'''
+    if m<=0: m = 1
+    if pvk_int < 0: pvk_int = N+pvk_int
+    start_pvk = fl(pvk_int).encode('utf8')
+    res = ice.privatekey_group_to_ETH_address(start_pvk, m)
+    addrlist = (ctypes.cast(res, ctypes.c_char_p).value).decode('utf8')
+    ice.free_memory(res)
+    return addrlist
+#==============================================================================
+def _privatekey_group_to_ETH_address_bytes(start_pvk, m):
+    res = (b'\x00') * (20 * m)
+    ice.privatekey_group_to_ETH_address_bytes(start_pvk, m, res)
+    return res
+def privatekey_group_to_ETH_address_bytes(pvk_int, m):
+    ''' Starting Privatekey Integer value passed to function as pvk_int.
+    Integer m is, how many times sequential increment is done from the starting key.
+    Output is bytes 20*m of ETH address lowercase without 0x'''
+    if m<=0: m = 1
+    if pvk_int < 0: pvk_int = N+pvk_int
+    start_pvk = fl(pvk_int).encode('utf8')
+    res = _privatekey_group_to_ETH_address_bytes(start_pvk, m)
+    return bytes(bytearray(res))
+#==============================================================================
+def bloom_check_add_mcpu(bigbuff, num_items, sz, mcpu, check_add, bloom_bits, bloom_hashes, bloom_filter):
+    found_array = (b'\x00') * num_items
+#    sz = 32; check_add = 0 for check and 1 for add
+    ice.bloom_check_add_mcpu(bigbuff, num_items, found_array, sz, mcpu, check_add, bloom_bits, bloom_hashes, bloom_filter)
+    return found_array
+#==============================================================================
+def to_cpub(pub_hex):
+    P = pub_hex
+    if len(pub_hex) > 70:
+        P = '02' + pub_hex[2:66] if int(pub_hex[66:],16)%2 == 0 else '03' + pub_hex[2:66]
+    return P
+#==============================================================================
+def point_to_cpub(pubkey_bytes):
+    P = pubkey_bytes.hex()
+    if len(P) > 70:
+        P = '02' + P[2:66] if int(P[66:],16)%2 == 0 else '03' + P[2:66]
+    return P
+#==============================================================================
+def pub2upub(pub_hex):
+    ''' Covert [C or U] pubkey to Point'''
+    x = pub_hex[2:66]
+    if len(pub_hex) < 70:
+        y = get_x_to_y(x, int(pub_hex[:2],16)%2 == 0).hex()
+    else:
+        y = pub_hex[66:].zfill(64)
+    return bytes.fromhex('04'+ x + y)
+#==============================================================================
+def bloom_para(_items, _fp = 0.000001):
+    _bits = math.ceil((_items * math.log(_fp)) / math.log(1 / pow(2, math.log(2))))
+    if _bits % 8: _bits = 8*(1 + (_bits//8))
+    _hashes = round((_bits / _items) * math.log(2))
+    return _bits, _hashes
+#==============================================================================
+def Fill_in_bloom(inp_list, _fp = 0.000001):
+    _bits, _hashes = bloom_para(len(inp_list), _fp)
+    _bf = (b'\x00') * (_bits//8)
+    for line in inp_list:
+        if type(line) != bytes: tt = str(line).encode("utf-8")
+        else: tt = line
+        res = ice.bloom_check_add(tt, len(tt), 1, _bits, _hashes, _bf)  # 1 = Add
+    del res
+    return _bits, _hashes, _bf, _fp, len(inp_list)
+#==============================================================================
+def dump_bloom_file(output_bloom_file_name, _bits, _hashes, _bf, _fp, _elem):
+    with open(output_bloom_file_name, 'wb') as f:
+        pickle.dump((_bits, _hashes, _bf, _fp, _elem), f)
+
+def read_bloom_file(bloom_file_name):
+    '''It will return the 5 output as _bits, _hashes, _bf, _fp, _elem'''
+    with open(bloom_file_name, 'rb') as f:
+        return pickle.load(f)
+#==============================================================================
+def check_in_bloom(this_line, _bits, _hashes, _bf):
+    if type(this_line) != bytes: tt = str(this_line).encode("utf-8")
+    else: tt = this_line
+    if ice.bloom_check_add(tt, len(tt), 0, _bits, _hashes, _bf) > 0: return True
+    else: return False
+#==============================================================================
+def create_bsgs_bloom_mcpu(mcpu, total_entries, _fp = 0.000001):
+    if total_entries%(mcpu*1000) != 0:
+        total_entries = mcpu*1000*(total_entries//(mcpu*1000))
+        if total_entries == 0: total_entries = mcpu * 1000
+        print('[*] Number of elements should be a multiple of 1000*mcpu. Automatically corrected it to nearest value:',total_entries)
+    _bits, _hashes = bloom_para(total_entries, _fp)
+    _bf = bytes(b'\x00') * (_bits//8)
+    print(f'[+] bloom [bits: {_bits}] [hashes: {_hashes}] [size: {_bits//8} Bytes] [false prob: {_fp}]')
+    ice.create_bsgs_bloom_mcpu(mcpu, total_entries, _bits, _hashes, _bf)
+    return _bits, _hashes, _bf, _fp, total_entries
+#==============================================================================
+def bsgs_2nd_check_prepare(bP_elem = 2000000000):
+    if bP_elem < 8000000: bP_elem = 8000000  # Less than 8 million is not allowed
+    ice.bsgs_2nd_check_prepare(bP_elem)
+#==============================================================================
+def dump_bsgs_2nd(output_bin_file, verbose = True):
+    '''output_bin_file is a binary dump file of bsgs_2nd_check_prepare data in RAM. 
+    It can be loaded using load_bsgs_2nd and then used in bsgs_2nd_check'''
+    ice.dump_bsgs_state(output_bin_file.encode("utf-8"), verbose)
+#==============================================================================
+def load_bsgs_2nd(input_bin_file, verbose = True):
+    '''input_bin_file is a binary dump file of bsgs_2nd_check_prepare data. 
+    It can be used in bsgs_2nd_check'''
+    ice.load_bsgs_state(input_bin_file.encode("utf-8"), verbose)
+#==============================================================================
+def bsgs_2nd_check(pubkey_bytes, z1_int):
+    if z1_int < 0: z1_int = N+z1_int
+    hex_value = fl(z1_int).encode('utf8')
+    res = (b'\x00') * 32
+    found = ice.bsgs_2nd_check(pubkey_bytes, hex_value, res)
+    return found, res
+#==============================================================================
+def bsgs_2nd_check_mcpu(concat_pubkey_bytes, z1_int, mcpu = os.cpu_count()):
+    '''upub 65 bytes of each pubkey, concatenated in concat_pubkey_bytes as input.
+    Output pvk will be 32 bytes in res corresponding to each pubkey, if matched.
+    for easy check found_array will contain either 0 or 1 for each element.
+    '''
+    if type(concat_pubkey_bytes) != bytes:
+        print("[Error] Input format [Bytes] allowed only. Detected : ", type(concat_pubkey_bytes))
+    num_items = len(concat_pubkey_bytes)//65
+    
+    if z1_int < 0: z1_int = N+z1_int
+    hex_value = fl(z1_int).encode('utf8')
+    res = (b'\x00') * (32 * num_items)
+    found_array = (b'\x00') * num_items
+    ice.bsgs_2nd_check_mcpu(concat_pubkey_bytes, num_items, mcpu, hex_value, res, found_array)
+    return found_array, res
+#==============================================================================
+def prepare_bin_file_work(in_file, out_file, lower = False):
+    use0x = False
+    inp_list = [line.split()[0].lower() if lower else line.split()[0] for line in open(in_file,'r')]
+    if inp_list[0][:2] == '0x': use0x = True
+    
+    with open(out_file, 'wb') as f:
+        if use0x:
+            inp_list = [line[2:] for line in inp_list]
+        inp_list.sort()
+        for line in inp_list:
+            f.write(bytes.fromhex(line))
+#==============================================================================
+def prepare_bin_file(in_file, out_file, overwrite = False, lower = False):
+    
+    if os.path.isfile(out_file) == False:
+        prepare_bin_file_work(in_file, out_file, lower)
+
+    else:
+        if not overwrite:
+            print(f'[+] File {out_file} already exist. It will be used as it is...')
+            
+        else:
+            print(f'[+] File {out_file} already exist. Overwriting it...')
+            prepare_bin_file_work(in_file, out_file)
+#==============================================================================
+def Load_data_to_memory(input_bin_file, verbose = False):
+    '''input_bin_file is sorted h160 data of 20 bytes each element. 
+    ETH address can also work without 0x if sorted binary format'''
+    ice.Load_data_to_memory(input_bin_file.encode("utf-8"), verbose)
+    
+#==============================================================================
+def check_collision(h160):
+    ''' h160 is the 20 byte hash to check for collision in data, already loaded in RAM.
+    Use the function Load_data_to_memory before calling this check'''
+    
+    found = ice.check_collision(h160)
+    return found
+#==============================================================================
+def check_collision_mcpu(h160_array, num_items = 1, mcpu = os.cpu_count()):
+    ''' h160_array is either a list of 20 byte hash to check for collision or 
+    a contiguous array of 20 * num_items bytes '''
+    if type(h160_array) == list: 
+        num_items = len(h160_array)
+        h160_array = b''.join(h160_array)
+        
+    found_array = (b'\x00') * num_items
+    ice.check_collision_mcpu(h160_array, num_items, mcpu, found_array)
+    return found_array
+#==============================================================================
+def xor_para(_items, _fp=0.000001):
+    ''' To be used for XOR Filters filling and checking purpose'''
+    _bits = int(-_items * math.log(_fp) / (math.log(2) ** 2))  # numer of bits
+    _hashes = int((_bits / _items) * math.log(2))  # number of hash
+    #_xf = (b'\x00') * ((_bits + 7) // 8)  # initialize the bit array
+    return _bits, _hashes#, _xf
+#==============================================================================
+def fill_in_xor(inp_list, _fp = 0.000001):
+    _bits, _hashes = xor_para(len(inp_list), _fp)
+    _xf = (b'\x00') * ((_bits + 7) // 8)  # initialize the bit array
+    for line in inp_list:
+        if type(line) != bytes: tt = str(line).encode("utf-8")
+        else: tt = line
+        res = ice.xor_filter_add(tt, len(tt), _bits, _hashes, _xf)
+    del res
+    return _bits, _hashes, _xf, _fp, len(inp_list)
+#==============================================================================
+def dump_xor_file(output_xor_file_name, _bits, _hashes, _xf, _fp, _elem):
+    with open(output_xor_file_name, 'wb') as f:
+        pickle.dump((_bits, _hashes, _xf, _fp, _elem), f)
+
+def read_xor_file(xor_file_name):
+    '''It will return the 5 output as _bits, _hashes, _xf, _fp, _elem'''
+    with open(xor_file_name, 'rb') as f:
+        return pickle.load(f)
+#==============================================================================
+def check_in_xor(this_line, _bits, _hashes, _xf):
+    if type(this_line) != bytes: tt = str(this_line).encode("utf-8")
+    else: tt = this_line
+    if ice.xor_filter_check(tt, len(tt), _bits, _hashes, _xf) > 0: return True
+    else: return False
+#==============================================================================
+def check_in_xor_mcpu(bigbuff, num_items, sz, mcpu, _bits, _hashes, _xf):
+    # sz = 32 if bigbuff is concatenated bytes of Xpoint with num_items elements
+    found_array = (b'\x00') * num_items
+    ice.xor_filter_check_mcpu(bigbuff, num_items, sz, mcpu, _bits, _hashes, _xf, found_array)
+    return found_array
+#==============================================================================
+def bsgs_xor_create_mcpu(mcpu, total_entries, _fp = 0.000001):
+    if total_entries%(mcpu*1000) != 0:
+        total_entries = mcpu*1000*(total_entries//(mcpu*1000))
+        if total_entries == 0: total_entries = mcpu * 1000
+        print('[*] Number of elements should be a multiple of 1000*mcpu. Automatically corrected it to nearest value:',total_entries)
+    _bits, _hashes = xor_para(total_entries, _fp)
+    _xf = (b'\x00') * ((_bits + 7) // 8)
+    print(f'[+] XOR [bits: {_bits}] [hashes: {_hashes}] [size: {len(_xf)} Bytes] [false prob: {_fp}]')
+    ice.bsgs_xor_create_mcpu(mcpu, total_entries, _bits, _hashes, _xf)
+    return _bits, _hashes, _xf, _fp, total_entries


### PR DESCRIPTION
…h computation

* **getz_input.py**
  - Use the `hashlib` module to compute the SHA-256 hash of the input data.
  - Add a check for witness data in the `parseTx` function and handle it separately.
  - Add debugging and logging for witness data.
  - Improve error handling in `split_sig_pieces` function.

* **rsz_rdiff_scan.py**
  - Add a check for witness data in the `parseTx` function and handle it separately.
  - Improve error handling in `split_sig_pieces` function.
  - Update the `HASH160` function to use `ice.pubkey_to_h160` directly.